### PR TITLE
feat: add support for SchallCircuitGroup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - [item=blueprint_reader_blueprint-combinator] Change subgroup to circuit-input if SchallCircuitGroup is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,2 @@
+-- Better subgroup placement with SchallCircuitGroup
+require("data-updates.schall-circuit-group")

--- a/data-updates/schall-circuit-group.lua
+++ b/data-updates/schall-circuit-group.lua
@@ -1,0 +1,3 @@
+if mods["SchallCircuitGroup"] then
+  data.raw.item["blueprint_reader_blueprint-combinator"].subgroup = "circuit-input"
+end

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.0",
-    "blueprint_reader >= 2.0.1"
+    "blueprint_reader >= 2.0.1",
+    "? SchallCircuitGroup >= 2.0.0"
   ]
 }


### PR DESCRIPTION
- [item=blueprint_reader_blueprint-combinator] Change subgroup to circuit-input if SchallCircuitGroup is installed.